### PR TITLE
同步`libccy/noname/noname-server.js`中的参数规格，且为linux端增加了编译脚本

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,17 @@ try {
 	// 示例: -s --maxAge 100
 	const argv = minimist(process.argv.slice(2), {
 		alias: { server: "s" },
-		default: { maxAge: oneYear },
+		default: {
+			server: false,
+			maxAge: oneYear,
+			port: 8089,
+			debug: false,
+		},
 	});
+
+	if (argv.debug) {
+		console.log(`argv:`, argv);
+	}
 
 	app.use(
 		bodyParser.json({
@@ -48,7 +57,7 @@ try {
 	});
 
 	// 根据参数设置 maxAge
-	const maxAge = argv.server ? argv.maxAge : 0;
+	const maxAge = argv.server && !argv.debug ? argv.maxAge : 0;
 
 	app.use(express.static(__dirname, { maxAge: maxAge }));
 
@@ -212,8 +221,8 @@ try {
 		return res.json(failedJson(400, String(err)));
 	});
 
-	app.listen(8089, () => {
-		console.log("应用正在使用 8089 端口以提供无名杀本地服务器功能!");
+	app.listen(argv.port, () => {
+		console.log(`应用正在使用 ${argv.port} 端口以提供无名杀本地服务器功能!`);
 		if (!process.argv[2]) require("child_process").exec("start http://localhost:8089/");
 	});
 

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+ncc build index.js -m -o dist
+node --experimental-sea-config sea-config.json
+cp $(command -v node) noname-server
+
+npx postject noname-server NODE_SEA_BLOB index.blob \
+    --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 \
+    --macho-segment-name NODE_SEA

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "npm run build:win && npm run build:mac",
     "build:win": "bash win-build.sh",
-    "build:mac": "bash mac-build.sh"
+    "build:mac": "bash mac-build.sh",
+    "build:linux": "bash linux-build.sh"
   },
   "pkg": {
     "targets": [


### PR DESCRIPTION
注意到：

- 本体中的`noname-server.js`和`index.js`存在参数上的差异
- 项目中未包含对linux端的编译脚本

总而言之，能跑

linux端和mac端由于共属于*nix体系，可执行文件惯用无后缀，导致会冲突，故默认的`build`依然只编译win和mac端的可执行文件